### PR TITLE
fix: adjust section title margin

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -44,7 +44,7 @@ hr {
 }
 
 .section-title-margin {
-  margin: 10% auto;
+  margin: 7% auto;
 }
 
 .section-with-subsections {


### PR DESCRIPTION
Summary:

The following commit contains an adjustment of the section title margin to be 7% instead of 10%

Reason:

This commit is made to show the cards better when navigating from the navbar

Testing:

I tested this manually

Notes:

a) Concerns:

None

b) Future commits can contain:

Not determined yet

reviewed-by: author