### PR TITLE
fix: change text in bachelor degrees

### DIFF
--- a/index.html
+++ b/index.html
@@ -193,15 +193,12 @@
               />
               <h4 class="card-subtitle text-body-secondary">East London</h4>
               <h4 class="card-subtitle mt-3">09/2017 - 08/2021</h4>
-              <p class="card-text lead mt-3">
-                Computer Engineering, GPA 3.64/4 with Excellent Honors
-              </p>
+              <p class="card-text lead mt-3">Computer Engineering</p>
+              <p class="card-text lead">GPA 3.64/4 with Excellent Honors</p>
             </div>
           </div>
         </div>
-        <div
-          class="col-sm-12 col-md-4 pt-sm-5 pt-md-0 d-flex align-items-stretch"
-        >
+        <div class="col-sm-12 col-md-4 pt-sm-5 pt-md-0">
           <div class="card">
             <div class="card-body mt-2 d-flex flex-column">
               <h2 class="card-title mb-3">Bachelor's Degree</h2>
@@ -215,9 +212,9 @@
               </h4>
               <h4 class="card-subtitle mt-3">09/2016 - 08/2021</h4>
               <p class="card-text lead mt-3">
-                Computer and Software Engineering, GPA 3.64/4 with Excellent
-                Honors
+                Computer and Software Engineering
               </p>
+              <p class="card-text lead">GPA 3.64/4 with Excellent Honors</p>
             </div>
           </div>
         </div>


### PR DESCRIPTION
Summary:

The following commit contains paragraphs separation in the bachelor degree cards

Reason:

This commit is made to add better looks to the bachelor cards

Testing:

I tested this manually

Notes:

a) Concerns:

None

b) Future commits can contain:

Not determined yet

reviewed-by: author