### PR TITLE
fix: adjust stretch of certification cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -341,12 +341,11 @@
     <h1 class="poppins text-center section-title section-title-margin">
       Certifications
     </h1>
-
     <div class="container section-margin text-center">
       <div class="row">
-        <div class="col-sm-12 col-md-4">
-          <div class="card">
-            <div class="card-body mt-2 d-flex flex-column">
+        <div class="col-sm-12 col-md-4 d-flex align-items-stretch">
+          <div class="card w-100">
+            <div class="card-body d-flex flex-column">
               <h2 class="card-title mb-3">Certified Tester</h2>
               <img
                 src="https://www.readynez.com/media/k1cfztw1/istqb-logo-png.png?width=274&height=205&mode=max"
@@ -355,13 +354,15 @@
               />
               <h4 class="card-subtitle text-body-secondary">ISTQB</h4>
               <h4 class="card-subtitle mt-3">10/2021</h4>
-              <p class="card-text lead mt-4">Score 82.5%</p>
+              <p class="card-text lead mt-3">Score 82.5%</p>
             </div>
           </div>
         </div>
-        <div class="col-sm-12 col-md-4 pt-sm-5 pt-md-0">
-          <div class="card">
-            <div class="card-body mt-2 d-flex flex-column">
+        <div
+          class="col-sm-12 col-md-4 pt-sm-5 pt-md-0 d-flex align-items-stretch"
+        >
+          <div class="card w-100">
+            <div class="card-body d-flex flex-column">
               <h2 class="card-title mb-3">Agile Tester</h2>
               <img
                 src="https://www.readynez.com/media/k1cfztw1/istqb-logo-png.png?width=274&height=205&mode=max"
@@ -370,13 +371,15 @@
               />
               <h4 class="card-subtitle text-body-secondary">ISTQB</h4>
               <h4 class="card-subtitle mt-3">11/2021</h4>
-              <p class="card-text lead mt-4">Score 90%</p>
+              <p class="card-text lead mt-3">Score 90%</p>
             </div>
           </div>
         </div>
-        <div class="col-sm-12 col-md-4 pt-sm-5 pt-md-0">
-          <div class="card">
-            <div class="card-body mt-2 d-flex flex-column">
+        <div
+          class="col-sm-12 col-md-4 pt-sm-5 pt-md-0 d-flex align-items-stretch"
+        >
+          <div class="card w-100">
+            <div class="card-body d-flex flex-column">
               <h2 class="card-title mb-3">Mobile Tester</h2>
               <img
                 src="https://www.readynez.com/media/k1cfztw1/istqb-logo-png.png?width=274&height=205&mode=max"
@@ -385,7 +388,7 @@
               />
               <h4 class="card-subtitle text-body-secondary">ISTQB</h4>
               <h4 class="card-subtitle mt-3">11/2021</h4>
-              <p class="card-text lead mt-4">Score 90%</p>
+              <p class="card-text lead mt-3">Score: 90%</p>
             </div>
           </div>
         </div>


### PR DESCRIPTION
Summary:

The following commit contains an adjustment of certification cards to stretch to height of tallest card

Reason:

This commit is made to avoid visual defects

Testing:

I tested this manually

Notes:

a) Concerns:

None

b) Future commits can contain:

Not determined yet

reviewed-by: author