### PR TITLE
fix: change school card text

### DIFF
--- a/index.html
+++ b/index.html
@@ -231,9 +231,8 @@
               />
               <h4 class="card-subtitle text-body-secondary mt-2">B.Karnak</h4>
               <h4 class="card-subtitle mt-3">09/2015 - 07/2016</h4>
-              <p class="card-text lead mt-3">
-                Grade: 99.27% - 155th on National-level
-              </p>
+              <p class="card-text lead mt-3">Grade 99.27%</p>
+              <p class="card-text lead">155th on National-level</p>
             </div>
           </div>
         </div>


### PR DESCRIPTION
Summary:

The following commit contains separated paragraphs of school card text

Reason:

This commit is made to follow the university cards

Testing:

I tested this manually

Notes:

a) Concerns:

None

b) Future commits can contain:

Not determined yet

reviewed-by: author