### PR TITLE
fix: add colons

### DIFF
--- a/index.html
+++ b/index.html
@@ -194,7 +194,7 @@
               <h4 class="card-subtitle text-body-secondary">East London</h4>
               <h4 class="card-subtitle mt-3">09/2017 - 08/2021</h4>
               <p class="card-text lead mt-3">Computer Engineering</p>
-              <p class="card-text lead">GPA 3.64/4 with Excellent Honors</p>
+              <p class="card-text lead">GPA: 3.64/4 with Excellent Honors</p>
             </div>
           </div>
         </div>
@@ -214,7 +214,7 @@
               <p class="card-text lead mt-3">
                 Computer and Software Engineering
               </p>
-              <p class="card-text lead">GPA 3.64/4 with Excellent Honors</p>
+              <p class="card-text lead">GPA: 3.64/4 with Excellent Honors</p>
             </div>
           </div>
         </div>
@@ -231,7 +231,7 @@
               />
               <h4 class="card-subtitle text-body-secondary mt-2">B.Karnak</h4>
               <h4 class="card-subtitle mt-3">09/2015 - 07/2016</h4>
-              <p class="card-text lead mt-3">Grade 99.27%</p>
+              <p class="card-text lead mt-3">Grade: 99.27%</p>
               <p class="card-text lead">155th on National-level</p>
             </div>
           </div>
@@ -353,7 +353,7 @@
               />
               <h4 class="card-subtitle text-body-secondary">ISTQB</h4>
               <h4 class="card-subtitle mt-3">10/2021</h4>
-              <p class="card-text lead mt-3">Score 82.5%</p>
+              <p class="card-text lead mt-3">Score: 82.5%</p>
             </div>
           </div>
         </div>
@@ -370,7 +370,7 @@
               />
               <h4 class="card-subtitle text-body-secondary">ISTQB</h4>
               <h4 class="card-subtitle mt-3">11/2021</h4>
-              <p class="card-text lead mt-3">Score 90%</p>
+              <p class="card-text lead mt-3">Score: 90%</p>
             </div>
           </div>
         </div>


### PR DESCRIPTION
Summary:

The following commit contains colons for grades, scores and GPA

Reason:

This commit is made to correct punctuation mistakes

Testing:

I tested this manually

Notes:

a) Concerns:

None

b) Future commits can contain:

Not determined yet

reviewed-by: author