### PR TITLE
fix: small introduction titles on mobile devices

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -96,6 +96,14 @@ i {
 }
 
 @media (min-width: 319px) and (max-width: 576px) {
+  .title {
+    font-size: 400%;
+  }
+
+  .star {
+    font-size: 400%;
+  }
+
   .section-title-margin {
     margin: 25% auto 30%;
   }


### PR DESCRIPTION
Summary:

The following commit contains larger introduction titles

Reason:

This commit is made to make introduction section larger

Testing:

I tested this manually

Notes:

a) Concerns:

None

b) Future commits can contain:

Not determined yet

reviewed-by: author