### PR TITLE
fix: add margin to weather image on mobile devices

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -127,4 +127,8 @@ i {
   .card-mb-xs {
     margin-bottom: 7%;
   }
+
+  .image-mb-xs {
+    margin-bottom: 10%;
+  }
 }

--- a/index.html
+++ b/index.html
@@ -282,7 +282,7 @@
               <img
                 src="https://cdn-icons-png.flaticon.com/512/1779/1779940.png"
                 alt="weather-logo"
-                class="w-50 align-self-center mb-sm-5 mb-md-3 mb-lg-4"
+                class="w-50 align-self-center mb-sm-5 mb-md-3 mb-lg-4 image-mb-xs"
               />
               <a
                 class="card-subtitle text-body-secondary text-decoration-none h4"


### PR DESCRIPTION
Summary:

The following commit contains bottom margin for weather image on mobile devices

Reason:

This commit is made to add space in weather app card when device is small

Testing:

I tested this manually

Notes:

a) Concerns:

None

b) Future commits can contain:

Not determined yet

reviewed-by: author