### PR TITLE
fix: [mobile] intro title not responsive

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -91,7 +91,7 @@ li > a:hover {
 }
 
 @media (min-width: 319px) and (max-width: 576px) {
-  .title {
+  .intro-title {
     font-size: 400%;
   }
 


### PR DESCRIPTION
Summary:

The following commit contains adding responsiveness to intro titles due to last commit naming refactor

Reason:

This commit is made to view the intro title correctly on mobile devices

Testing:

I tested this manually

Notes:

a) Concerns:

None

b) Future commits can contain:

Not determined yet

reviewed-by: author