### PR TITLE
fix: load java jquery express mongodb on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -423,7 +423,7 @@
             <div class="card-body mt-2 d-flex flex-column">
               <h2 class="card-title mb-5">Java</h2>
               <img
-                src="https://cdn.icon-icons.com/icons2/2415/PNG/512/java_original_wordmark_logo_icon_146459.png"
+                src="https://cdn-icons-png.flaticon.com/512/226/226777.png"
                 alt="java-logo"
                 class="w-50 align-self-center mb-3"
               />
@@ -495,7 +495,7 @@
             <div class="card-body mt-2 d-flex flex-column">
               <h2 class="card-title mb-5">jQuery</h2>
               <img
-                src="https://cdn.icon-icons.com/icons2/2699/PNG/512/jquery_logo_icon_167804.png"
+                src="https://cdn.icon-icons.com/icons2/2415/PNG/512/jquery_plain_logo_icon_146444.png"
                 alt="jquery-logo"
                 class="w-50 align-self-center mb-3"
               />
@@ -608,7 +608,7 @@
             <div class="card-body mt-2 d-flex flex-column">
               <h2 class="card-title mb-5">Express</h2>
               <img
-                src="https://cdn.icon-icons.com/icons2/2699/PNG/512/expressjs_logo_icon_169185.png"
+                src="https://wsofter.ru/wp-content/uploads/2017/12/node-express.png"
                 alt="express-logo"
                 class="w-50 align-self-center mb-3"
               />
@@ -622,7 +622,7 @@
             <div class="card-body mt-2 d-flex flex-column">
               <h2 class="card-title mb-5">MongoDB</h2>
               <img
-                src="https://cdn.icon-icons.com/icons2/2415/PNG/512/mongodb_original_logo_icon_146424.png"
+                src="https://miro.medium.com/v2/resize:fit:512/1*doAg1_fMQKWFoub-6gwUiQ.png"
                 alt="mongodb-logo"
                 class="w-50 align-self-center mb-3"
               />


### PR DESCRIPTION
Summary:

The following commit contains new image URLs for the indicated cards

Reason:

This commit is made to make images load on mobile devices

Testing:

I tested this manually

Notes:

a) Concerns:

None

b) Future commits can contain:

Not determined yet

reviewed-by: author