### PR TITLE
fix: jquery image does not load on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -495,7 +495,7 @@
             <div class="card-body mt-2 d-flex flex-column">
               <h2 class="card-title mb-5">jQuery</h2>
               <img
-                src="https://cdn.icon-icons.com/icons2/2699/PNG/512/jquery_logo_icon_167804.png"
+                src="https://static-00.iconduck.com/assets.00/jquery-icon-icon-512x507-kvrw1iok.png"
                 alt="jquery-logo"
                 class="w-50 align-self-center mb-3"
               />


### PR DESCRIPTION
Summary:

The following commit contains new image URL for jquery

Reason:

This commit is made to view jquery image on mobile

Testing:

I tested this manually

Notes:

a) Concerns:

None

b) Future commits can contain:

Not determined yet

reviewed-by: author